### PR TITLE
Proofreading days 1-4. Suggestions enumerated below:

### DIFF
--- a/docs/00.md
+++ b/docs/00.md
@@ -18,13 +18,13 @@ This is a log of me going through Cats, a functional programming library for Sca
 that is currently *experimental* and under active development.
 I'll try to follow the structure of [learning Scalaz][lsz] that I wrote in 2012 (!).
 
-Cats [website][cats] says the name is a playful shortening of the word category.
-They say coordinating programmers are like herding cats
-(as in attempting to move dozens of them in a direction like cattles, while cats have their own ideas),
-and it seems to be true at least for those of us using Scala. Keenly aware of this situation, cats list
-approachability as their first motivation.
+Cats' [website][cats] says the name is a playful shortening of the word category.
+It says coordinating programmers is like herding cats
+(as in attempting to move dozens of them in a direction like cattle, while cats have their own ideas),
+and it seems to be true at least for those of us using Scala. Keenly aware of this situation, Cats' site lists
+approachability as the first motivation.
 
-Cats also look interesting from the technical perspective.
+Cats also looks interesting from the technical perspective.
 With its approachability and Erik Asheim ([@d6][@d6]/[@non][@non])'s awesomeness,
 [people][contributors] are gathering around them with new ideas such as
 Michael Pilquist ([@mpilquist][@mpilquist])'s [simulacrum][simulacrum] and

--- a/docs/01/b.md
+++ b/docs/01/b.md
@@ -2,13 +2,13 @@
   [algebra]: https://github.com/non/algebra
   [Equivalence]: http://en.wikipedia.org/wiki/Equivalence_relation
 
-## Eq
+## `Eq`
 
 LYAHFGG:
 
 > `Eq` is used for types that support equality testing. The functions its members implement are `==` and `/=`.
 
-Cats equivalent for the `Eq` typeclass is also called `Eq`.
+Cats' equivalent for the `Eq` typeclass is also called `Eq`.
 Technically speaking, `cats.Eq` is actually a type alias of `algebra.Eq` from [non/algebra][algebra].
 Not sure if it matters, but it's probably a good idea that it's being reused:
 
@@ -47,9 +47,9 @@ trait Eq[@sp A] extends Any with Serializable { self =>
 ```
 
 This is an example of polymorphism. Whatever equality means for the type `A`,
-`neqv` is the opposite of it. Does not matter if it's `String`, `Int`, or whatever.
+`neqv` is the opposite of it. It does not matter if it's `String`, `Int`, or whatever.
 Another way of looking at it is that given `Eq[A]`, `===` is universally the opposite of `=!=`.
 
-I'm a bit concerned that `Eq` seems to be using the term equal and equivalent
+I'm a bit concerned that `Eq` seems to be using the terms "equal" and "equivalent"
 interchangably. [Equivalence relationship][Equivalence] could include "having the same birthday"
 whereas equality also requires substitution property.

--- a/docs/01/c.md
+++ b/docs/01/c.md
@@ -1,11 +1,11 @@
 
-### Order
+### `Order`
 
 LYAHFGG:
 
 > `Ord` is for types that have an ordering. `Ord` covers all the standard comparing functions such as `>`, `<`, `>=` and `<=`.
 
-Cats equivalent for the `Ord` typeclass is `Order`.
+Cats' equivalent for the `Ord` typeclass is `Order`.
 As with `Eq`, `cats.Order` is actually a type alias of `algebra.Order`.
 
 ```console:new

--- a/docs/01/d.md
+++ b/docs/01/d.md
@@ -1,5 +1,5 @@
 
-### PartialOrder
+### `PartialOrder`
 
 In addition to `Order`, Cats also defines `PartialOrder`.
 This also is a type alias to `algebra.PartialOrder`.

--- a/docs/01/e.md
+++ b/docs/01/e.md
@@ -1,11 +1,11 @@
 
-### Show
+### `Show`
 
 LYAHFGG:
 
 > Members of `Show` can be presented as strings.
 
-Cats equivalent for the `Show` typeclass is `Show`:
+Cats' equivalent for the `Show` typeclass is `Show`:
 
 ```console:new
 scala> import cats._, cats.std.all._, cats.syntax.show._
@@ -16,7 +16,7 @@ scala> "hello".show
 At first, it might seem silly to define `Show` because Scala
 already has `toString` on `Any`.
 `Any` also means anything would match the criteria, so you lose type safety.
-The `toString` could be a junk supplied by some parent class:
+The `toString` could be junk supplied by some parent class:
 
 ```console
 scala> (new {}).toString

--- a/docs/01/f.md
+++ b/docs/01/f.md
@@ -1,11 +1,11 @@
 
-### Read
+### `Read`
 
 LYAHFGG:
 
 > `Read` is sort of the opposite typeclass of `Show`. The `read` function takes a string and returns a type which is a member of `Read`.
 
-I could not find Cats equivalent for this typeclass.
+I could not find Cats' equivalent for this typeclass.
 
 I find myself defining `Read` and its variant `ReadJs` time and time again.
 Stringly typed programming is ugly.

--- a/docs/01/g.md
+++ b/docs/01/g.md
@@ -2,13 +2,13 @@
   [IntervalsTalk]: https://newcircle.com/s/post/1729/intervals_unifying_uncertainty_ranges_and_loops_erik_osheim_video
   [spire]: https://github.com/non/spire
 
-### Enum
+### `Enum`
 
 LYAHFGG:
 
 > `Enum` members are sequentially ordered types — they can be enumerated. The main advantage of the `Enum` typeclass is that we can use its types in list ranges. They also have defined successors and predecessors, which you can get with the `succ` and `pred` functions.
 
-I could not find Cats equivalent for this typeclass.
+I could not find Cats' equivalent for this typeclass.
 
-Not an `Enum` or range, but [non/spire][spire] has an interesting data structure called `Interval`.
+It's not an `Enum` or range, but [non/spire][spire] has an interesting data structure called `Interval`.
 Check out Erik's [Intervals: Unifying Uncertainty, Ranges, and Loops][IntervalsTalk] talk from nescala 2015.

--- a/docs/01/h.md
+++ b/docs/01/h.md
@@ -1,13 +1,13 @@
 
   [spire]: https://github.com/non/spire
 
-### Numeric
+### `Numeric`
 
 LYAHFGG:
 
 > `Num` is a numeric typeclass. Its members have the property of being able to act like numbers.
 
-I could not find Cats equivalent for this typeclass,
+I could not find Cats' equivalent for this typeclass,
 but [spire][spire] defines `Numeric`. Cats doesn't define `Bounds` either.
 
 So far we've seen some of typeclasses that are *not* defined in Cats.

--- a/docs/01/i.md
+++ b/docs/01/i.md
@@ -67,4 +67,4 @@ scala> implicit val trafficLightEq: Eq[TrafficLight] =
 scala> TrafficLight.red === TrafficLight.yellow
 ```
 
-It is a bit of a boilderplate, but it works.
+It is a bit of boilerplate, but it works.

--- a/docs/02/a.md
+++ b/docs/02/a.md
@@ -24,7 +24,7 @@ The conventional steps of defining a modular typeclass in Scala used to look lik
 
 Frankly, these steps are mostly copy-paste boilerplate except for the first one.
 Enter Michael Pilquist ([@mpilquist][@mpilquist])'s [simulacrum][simulacrum].
-simulacrum magically generates most of steps 2-4 just by putting `@typeclass` annotation.
+Simulacrum magically generates most of steps 2-4 just by putting `@typeclass` annotation.
 By chance, Stew O'Connor ([@stewoconnor][@stewoconnor]/[@stew][@stew])'s [#294][294] got merged,
 which refactors Cats to use it.
 
@@ -84,7 +84,7 @@ object CanTruthy {
 }
 ```
 
-To make sure it works, let's define an instance for `Int` and use it. Eventual goal is to get `1.truthy` to return `true`:
+To make sure it works, let's define an instance for `Int` and use it. The eventual goal is to get `1.truthy` to return `true`:
 
 ```console
 scala> implicit val intCanTruthy: CanTruthy[Int] = CanTruthy.fromTruthy({
@@ -100,7 +100,7 @@ One caveat is that this requires Macro Paradise plugin to compile. Once it's com
 
 ### Symbolic operators
 
-For `CanTruthy` the injected operator happened to be unary, and it matched the name of the function on the typeclass contract. simulacrum can also define operator with symbolic names using `@op` annotation:
+For `CanTruthy` the injected operator happened to be unary, and it matched the name of the function on the typeclass contract. Simulacrum can also define operator with symbolic names using `@op` annotation:
 
 ```console
 scala> @typeclass trait CanAppend[A] {

--- a/docs/02/b.md
+++ b/docs/02/b.md
@@ -35,8 +35,8 @@ scala> Functor[List].map(List(1, 2, 3)) { _ + 1 }
 
 Let's call the above usage the *function syntax*.
 
-We now know that `@typeclass` annotation will automatically turn `map` function into `map` operator.
-The `fa` part turns into `this` of the method, and the second parameter list will now be
+We now know that `@typeclass` annotation will automatically turn a `map` function into a `map` operator.
+The `fa` part turns into the `this` of the method, and the second parameter list will now be
 the parameter list of `map` operator:
 
 ```scala
@@ -73,7 +73,7 @@ One workaround is to opt for the function syntax.
 
 #### Function as a functor
 
-Cats also defines `Functor` instance for `Function1`.
+Cats also defines a `Functor` instance for `Function1`.
 
 ```console
 scala> val h = ((x: Int) => x + 1) map {_ * 7}
@@ -87,7 +87,7 @@ This is interesting. Basically `map` gives us a way to compose functions, except
 >
 > What does the type `fmap :: (a -> b) -> (r -> a) -> (r -> b)` for this instance tell us? Well, we see that it takes a function from `a` to `b` and a function from `r` to `a` and returns a function from `r` to `b`. Does this remind you of anything? Yes! Function composition!
 
-Oh man, LYAHFGG came to the same conclusion as I did about the function composition. But wait..
+Oh man, LYAHFGG came to the same conclusion as I did about the function composition. But wait...
 
 ```haskell
 ghci> fmap (*3) (+100) 1
@@ -96,7 +96,7 @@ ghci> (*3) . (+100) \$ 1
 303
 ```
 
-In Haskell, the `fmap` seems to be working as the same order as `f compose g`. Let's check in Scala using the same numbers:
+In Haskell, the `fmap` seems to be working in the same order as `f compose g`. Let's check in Scala using the same numbers:
 
 ```console
 scala> (((_: Int) * 3) map {_ + 100}) (1)
@@ -140,7 +140,7 @@ fmap (replicate 3) :: (Functor f) => f a -> f [a]
 ```
 
 If the parameter order has been flipped, are we going to miss out on this lifting goodness?
-Fortunately, Cats implement derived functions under the `Functor` typeclass:
+Fortunately, Cats implements derived functions under the `Functor` typeclass:
 
 ```scala
 @typeclass trait Functor[F[_]] extends functor.Invariant[F] { self =>
@@ -216,4 +216,3 @@ scala> assert { (x map (f map g)) === (x map f map g) }
 ```
 
 These are laws the implementer of the functors must abide, and not something the compiler can check for you. 
-

--- a/docs/02/c.md
+++ b/docs/02/c.md
@@ -8,7 +8,7 @@ out: checking-laws-with-discipline.html
 
 ### Checking laws with Discipline
 
-Compiler can't check for the laws, but Cat ships with `FunctorLaws` traits that describes this in [code][FunctorLawsSource]:
+The compiler can't check for the laws, but Cats ships with a `FunctorLaws` trait that describes this in [code][FunctorLawsSource]:
 
 ```scala
 /**
@@ -25,10 +25,10 @@ trait FunctorLaws[F[_]] extends InvariantLaws[F] {
 }
 ```
 
-#### Checking laws from REPL
+#### Checking laws from the REPL
 
 This is based on a library called [Discipline][Discipline], which is a wrapper around ScalaCheck.
-We can run these tests from REPL with ScalaCheck.
+We can run these tests from the REPL with ScalaCheck.
 
 ```scala
 scala> import cats._, cats.std.all._
@@ -145,7 +145,7 @@ scala> import example._
 scala> (CSome(0, "ho"): COption[String]) map {identity}
 ```
 
-This breaks the first law.
+This breaks the first law because the result of the `identity` function is not equal to the input.
 To catch this we need to supply an "arbitrary" `COption[A]` implicitly:
 
 ```scala

--- a/docs/03/a.md
+++ b/docs/03/a.md
@@ -14,7 +14,7 @@ out: Kinds.html
 > ...
 > What are kinds and what are they good for? Well, let's examine the kind of a type by using the :k command in GHCI.
 
-Scala 2.10 didn't have `:k` command, so I wrote [kind.scala](https://gist.github.com/eed3si9n/3610635).
+Scala 2.10 didn't have a `:k` command, so I wrote [kind.scala](https://gist.github.com/eed3si9n/3610635).
 Thanks to George Leontiev ([@folone](https://twitter.com/folone)) and others, `:kind` command is now part of Scala 2.11 ([scala/scala#2340][scala2340]). Let's try using it:
 
 ```scala
@@ -27,7 +27,7 @@ scala.Int's kind is A
 This is a proper type.
 ```
 
-`Int` and every other types that you can make a value out of is called a proper type and denoted with a symbol `*` (read "type"). This is analogous to value `1` at value-level. Using Scala's type variable notation this could be written as `A`.
+`Int` and every other types that you can make a value out of are called a proper type and denoted with a `*` symbol (read "type"). This is analogous to the value `1` at value-level. Using Scala's type variable notation this could be written as `A`.
 
 ```scala
 scala> :k -v Option
@@ -54,7 +54,7 @@ This is a type constructor: a 1st-order-kinded type.
 
 Scala encodes (or complects) the notion of typeclasses using type constructors.
 When looking at this, think of it as `Eq` is a typeclass for `A`, a proper type.
-This should make sense because you would pass in `Int` into `Eq`.
+This should make sense because you would pass `Int` into `Eq`.
 
 ```scala
 scala> :k -v Functor
@@ -65,7 +65,7 @@ This is a type constructor that takes type constructor(s): a higher-kinded type.
 
 Again, Scala encodes typeclasses using type constructors,
 so when looking at this, think of it as `Functor` is a typeclass for `F[A]`, a type constructor.
-This should also make sense because you would pass in `List` into `Functor`.
+This should also make sense because you would pass `List` into `Functor`.
 
 In other words, this is a type constructor that accepts another type constructor.
 This is analogous to a higher-order function, and thus called *higher-kinded type*.
@@ -74,8 +74,8 @@ These are denoted as `(* -> *) -> *`. Using Scala's type variable notation this 
 ### forms-a vs is-a
 
 The terminology around typeclasses tends to get jumbled up.
-For example, The pair `(Int, +)` forms a typeclass called monoid. 
-Colloquially, we say things like "is X a monoid?" to mean "can X form a monoid under some operation?"
+For example, the pair `(Int, +)` forms a typeclass called monoid. 
+Colloquially, we say things like "is _X_ a monoid?" to mean "can _X_ form a monoid under some operation?"
 
-An example of this is `Either[A, B]`, which we implied that it "is-a" functor yesterday.
-This is not completely accurate, because even though it might not be useful, we *could have* defined another left biased functor.
+An example of this is `Either[A, B]`, which we implied "is-a" functor yesterday.
+This is not completely accurate because, even though it might not be useful, we *could have* defined another left-biased functor.

--- a/docs/03/b.md
+++ b/docs/03/b.md
@@ -2,7 +2,7 @@
   [fafm]: http://learnyouahaskell.com/functors-applicative-functors-and-monoids
   [mootws]: making-our-own-typeclass-with-simulacrum.html
 
-### Apply
+### `Apply`
 
 [Functors, Applicative Functors and Monoids][fafm]:
 
@@ -42,7 +42,7 @@ trait Apply[F[_]] extends Functor[F] with ApplyArityFunctions[F] { self =>
 ```
 
 Note that `Apply` extends `Functor`.
-The `<*>` function is called `ap` in Cats's `Apply`. (This was origianlly called `apply`, but was renamed to `ap`. +1)
+The `<*>` function is called `ap` in Cats's `Apply`. (This was originally called `apply`, but was renamed to `ap`. +1)
 
 LYAHFGG:
 
@@ -70,7 +70,7 @@ scala> 9.some
 scala> none[Int]
 ```
 
-#### Option as an Apply
+#### `Option` as an `Apply`
 
 Here's how we can use it with `Apply[Option].ap`:
 
@@ -96,7 +96,7 @@ scala> "woot".some ap (none[String => String])
 ```
 
 I see what it did, but I would be confused if I saw this in some code.
-<s>Abbreviating `apply` here would be a bad idea.</s>
+<s>Abbreviating `apply` here by eliding the function name would be a bad idea.</s>
 
 #### The Applicative Style
 
@@ -113,7 +113,7 @@ ghci> pure (-) <*> Just 3 <*> Just 5
 Just (-2)
 ```
 
-Cats comes with the ApplyBuilder syntax.
+Cats comes with the `ApplyBuilder` syntax.
 
 ```console
 scala> import cats.syntax.apply._
@@ -122,19 +122,19 @@ scala> (none[Int] |@| 5.some) map { _ - _ }
 scala> (3.some |@| none[Int]) map { _ - _ }
 ```
 
-#### List as an Apply
+#### `List` as an `Apply`
 
 LYAHFGG:
 
 > Lists (actually the list type constructor, `[]`) are applicative functors. What a surprise!
 
-Let's see if we can use the ApplyBuilder sytax:
+Let's see if we can use the `ApplyBuilder` sytax:
 
 ```console
 scala> (List("ha", "heh", "hmm") |@| List("?", "!", ".")) map {_ + _}
 ```
 
-#### Useful functions for Apply
+#### Useful functions for `Apply`
 
 LYAHFGG:
 
@@ -177,7 +177,7 @@ trait Apply[F[_]] extends Functor[F] with ApplyArityFunctions[F] { self =>
 }
 ```
 
-For binary operators, `map2` can be used to hide the applicative sytle.
+For binary operators, `map2` can be used to hide the applicative style.
 Here we can write the same thing in two different ways:
 
 ```console
@@ -203,12 +203,12 @@ scala> Apply[Option].tuple2(1.some, none[Int])
 
 If you are wondering what happens when you have a function with more than two
 parameters, note that `Apply[F[_]]` extends `ApplyArityFunctions[F]`.
-This is an auto-generated code that defines `ap3`, `map3`, `tuple3`, ... up to
+This is auto-generated code that defines `ap3`, `map3`, `tuple3`, ... up to
 `ap22`, `map22`, `tuple22`.
 
-#### `*>` and `<*` operator
+#### `*>` and `<*` operators
 
-`Apply` enables two operators `<*` and `*>` which are special cases of `Apply[F].map2`:
+`Apply` enables two operators, `<*` and `*>`, which are special cases of `Apply[F].map2`:
 
 
 ```scala
@@ -238,9 +238,9 @@ scala> none[Int] *> 2.some
 
 If either side fails, we get `None`.
 
-#### Apply law
+#### `Apply` law
 
-Apply has a single law called composition:
+`Apply` has a single law called composition:
 
 ```scala
 trait ApplyLaws[F[_]] extends FunctorLaws[F] {

--- a/docs/03/c.md
+++ b/docs/03/c.md
@@ -1,7 +1,7 @@
   [Apply]: Apply.html
   [fafm]: http://learnyouahaskell.com/functors-applicative-functors-and-monoids
 
-### Applicative
+### `Applicative`
 
 **Note**: If you jumped to this page because you're interested in applicative functors,
 you should definitely read [Apply][Apply] first.
@@ -48,7 +48,7 @@ scala> F.ap(F.pure(9)) { F.pure((_: Int) + 3) }
 
 We've abstracted `Option` away from the code.
 
-#### Useful functions for Applicative
+#### Useful functions for `Applicative`
 
 LYAHFGG:
 
@@ -87,7 +87,7 @@ scala> sequenceA(List(List(1, 2, 3), List(4, 5, 6)))
 ```
 
 We got the right answers. What's interesting here is that we did end up needing
-`Applicative` after all, and `sequenceA` is generic in typeclassy way.
+`Applicative` after all, and `sequenceA` is generic in a typeclassy way.
 
 > Using `sequenceA` is useful when we have a list of functions and we want
 > to feed the same input to all of them and then view the list of results.
@@ -99,7 +99,7 @@ scala> val f = sequenceA[Function1[Int, ?], Int](List((_: Int) + 3, (_: Int) + 2
 scala> f(3)
 ```
 
-#### Applicative Laws
+#### `Applicative` Laws
 
 Here are the laws for `Applicative`:
 

--- a/docs/04/a.md
+++ b/docs/04/a.md
@@ -5,9 +5,9 @@ out: Semigroup.html
   [clwd]: checking-laws-with-discipline.html
   [fafm]: http://learnyouahaskell.com/functors-applicative-functors-and-monoids
 
-### Semigroup
+### `Semigroup`
 
-If you have the book Learn You a Haskell for Great Good you get to start a new chapter: Monoids. For the website, it's still [Functors, Applicative Functors and Monoids][fafm].
+If you have the book _Learn You a Haskell for Great Good_ you get to start a new chapter: "Monoids." For the website, it's still [Functors, Applicative Functors and Monoids][fafm].
 
 First, it seems like Cats is missing `newtype`/tagged type facility.
 We'll implement our own later.
@@ -58,13 +58,13 @@ scala> List(1, 2, 3) |+| List(4, 5, 6)
 scala> "one" |+| "two"
 ```
 
-#### The Semigroup Laws
+#### The `Semigroup` Laws
 
-The associativity is the only law for `Semigroup`.
+Associativity is the only law for `Semigroup`.
 
 - associativity `(x |+| y) |+| z = x |+| (y |+| z)`
 
-Here's how we can check the Semigroup laws from REPL.
+Here's how we can check the Semigroup laws from the REPL.
 Review [Checking laws with discipline][clwd] for the details:
 
 ```scala
@@ -94,7 +94,7 @@ scala> rs2.all.check
 + semigroup.serializable: OK, proved property.
 ```
 
-#### Lists are Semigroups
+#### `List`s are `Semigroup`s
 
 ```console
 scala> List(1, 2, 3) |+| List(4, 5, 6)
@@ -115,7 +115,7 @@ scala> doSomething(3, 5)(Semigroup.additive[Int])
 scala> doSomething(3, 5)(Semigroup.multiplicative[Int])
 ```
 
-I might as well stick to function sytanx:
+I might as well stick to function syntax:
 
 ```console
 scala> Semigroup.additive[Int].combine(3, 5)

--- a/docs/04/b.md
+++ b/docs/04/b.md
@@ -5,7 +5,7 @@ out: Monoid.html
   [value-classes-overview]: http://docs.scala-lang.org/overviews/core/value-classes.html
   [algebra13]: https://github.com/non/algebra/issues/13
 
-### Monoid
+### `Monoid`
 
 LYAHFGG:
 
@@ -50,13 +50,13 @@ trait Monoid[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] {
 
 #### Monoid laws
 
-In addition to Semigroup law, monoid must satify two more laws:
+In addition to the semigroup law, monoid must satify two more laws:
 
 - associativity `(x |+| y) |+| z = x |+| (y |+| z)`
 - left identity `Monoid[A].empty |+| x = x`
 - right identity `x |+| Monoid[A].empty = x`
 
-Here's how we can check Monoid laws from REPL:
+Here's how we can check monoid laws from the REPL:
 
 ```scala
 scala> import cats._, cats.std.all._
@@ -122,7 +122,7 @@ LYAHFGG:
 
 > The *newtype* keyword in Haskell is made exactly for these cases when we want to just take one type and wrap it in something to present it as another type.
 
-Cats does not ship with tagged type facility, but Scala now has [value classes][value-classes-overview]. This will remain unboxed under certain conditions, so it should work for simple examples.
+Cats does not ship with a tagged-type facility, but Scala now has [value classes][value-classes-overview]. This will remain unboxed under certain conditions, so it should work for simple examples.
 
 ```console:new
 scala> :paste
@@ -137,7 +137,7 @@ LYAHFGG:
 > ...
 > The other way for `Bool` to be an instance of `Monoid` is to kind of do the opposite: have `&&` be the binary function and then make `True` the identity value.
 
-Cats does not provide this, but we can implement this ourselves.
+Cats does not provide this, but we can implement it ourselves.
 
 ```console:new
 scala> import cats._, cats.std.all._, cats.syntax.semigroup._
@@ -184,7 +184,7 @@ scala> val x4 = Monoid[Conjunction].empty |+| Conjunction(true)
 scala> x4.unwrap
 ```
 
-We should check if our custom new types satisfy the Monoid laws.
+We should check if our custom new types satisfy the the monoid laws.
 
 ```scala
 scala> import algebra.laws.GroupLaws
@@ -213,7 +213,7 @@ scala> rs1.all.check
 ```
 
 The test failed because our monoid is not `Serializable`.
-I'm confused as to why Monoid law is checking for `Serializable`.
+I'm confused as to why the monoid law is checking for `Serializable`.
 [non/algebra#13][algebra13] says it's convenient for Spark. I feel like this should be a separate thing.
 
 ```scala
@@ -261,7 +261,7 @@ Let's see if this is how Cats does it.
     }
 ```
 
-If we replace `mappend` with equivalent `combine`, the rest is just pattern matching.
+If we replace `mappend` with the equivalent `combine`, the rest is just pattern matching.
 Let's try using it.
 
 ```console
@@ -355,7 +355,7 @@ scala> Last('a'.some) |+| Last('b'.some)
 scala> Last('a'.some) |+| Last(none[Char])
 ```
 
-More law checking.
+More law checking:
 
 ```scala
 scala> implicit def arbLast[A: Eq](implicit ev: Arbitrary[Option[A]]): Arbitrary[Last[A]] =

--- a/docs/04/c.md
+++ b/docs/04/c.md
@@ -4,24 +4,24 @@ out: about-laws.htmls
 
 ### About Laws
 
-Lots of things around laws today. Why do we need laws anyway?
+We covered lots of things around laws today. Why do we need laws anyway?
 
-Laws are important because laws are important, is tautological statement, but there's a grain of truth to it. Like traffic laws dictating that we drive on one side within a patch of land, some laws are convenient *if everyone followed them*.
+Laws are important because laws are important is a tautological statement, but there's a grain of truth to it. Like traffic laws dictating that we drive on one side within a patch of land, some laws are convenient *if everyone follows them*.
 
-What Cats/Haskell style of function programming allows us to do is
+What Cats/Haskell-style function programming allows us to do is
 write code that abstracts out the data, container, execution model, etc.
-The abstraction will make only the assumption about stated in the laws,
+The abstraction will make only the assumptions stated in the laws,
 thus each `A: Monoid` needs to satisfy the laws for the abstracted code to behave properly. We can call this the *utilitarian* view.
 
 Even if we could accept the utility, why those laws? It's because it's on 
-HaskellWiki or one of SPJ papers. They might offer a starting point with an existing implementation, which we can mimic.
+HaskellWiki or one of SPJ's papers. They might offer a starting point with an existing implementation, which we can mimic.
 We can call this the *traditionalist* view. However, there is a danger of inheriting the design choices or even limitations that were made specifically for Haskell.
 Functor in category theory, for instance, is a more general term than `Functor[F]`. At least `fmap` is a function that returns `F[A] => F[B]`, which is related.
 By the time we get to `map` in Scala, we lose that because of type inference.
 
 Eventually we should tie our understanding back to math.
 Monoid laws correspond with the mathematical definition of monoids, and from there we can reap the benefits of the known properties of monoids.
-This is relevant especially for Monoid laws, because the three laws are the same as the axioms of the category, because a monoid is a special case of a category.
+This is relevant especially for monoid laws, because the three laws are the same as the axioms of the category, because a monoid is a special case of a category.
 
 For the sake of learning, I think it's ok to start out with cargo cult.
 We all learn language through imitation and pattern recognition.

--- a/docs/04/d.md
+++ b/docs/04/d.md
@@ -69,7 +69,7 @@ scala> Foldable[List].foldLeft(List(1, 2, 3), 1) {_ * _}
 
 `Foldable` comes with some useful functions/operators,
 many of them taking advantage of the typeclasses.
-Let's try the `fold`. `Monoid[A]` gives us `empty` and `combine`, so that's enough information to fold things over.
+Let's try the `fold`. `Monoid[A]` gives us `empty` and `combine`, so that's enough information to fold over things.
 
 ```scala
   /**


### PR DESCRIPTION
- Correct typos and misspellings
- Insert definite and indefinite articles
- Consistently enclose type names in backticks in headings
- Attempt to apply consistent capitalization to "_x_ laws"
- Apply punctuation rules for tiles and words used per se
