### PR TITLE
Consistently spell "datatype" as one word.

### DIFF
--- a/docs/01/i.md
+++ b/docs/01/i.md
@@ -9,7 +9,7 @@ out: typeclasses-102.html
 
 I am now going to skip over to Chapter 8 [Making Our Own Types and Typeclasses][moott] (Chapter 7 if you have the book) since the chapters in between are mostly about Haskell syntax.
 
-### A traffic light data type
+### A traffic light datatype
 
 ```haskell
 data TrafficLight = Red | Yellow | Green

--- a/docs/08/c.md
+++ b/docs/08/c.md
@@ -84,7 +84,7 @@ In WFMM's original DSL, `Output b next` has two type parameters `b` and `next`.
 This allows `Output` to be generic about the output type.
 As demonstrated above as `Toy`, Scala can do this too.
 But doing so unnecessarily complicates the demonstration of `Free` because of
-Scala's handling of partially applied types. So we'll first hardcode the data type to `Char` as follows:
+Scala's handling of partially applied types. So we'll first hardcode the datatype to `Char` as follows:
 
 ```console
 scala> :paste

--- a/docs/08/d.md
+++ b/docs/08/d.md
@@ -114,7 +114,7 @@ type Option[+A] = Free[Trivial, A]
 There's also iteratees implementation based on free monads.
 Finally, he summarizes free monads in nice bullet points:
 
-> - A model for any recursive datatype with data at the leaves.
+> - A model for any recursive data type with data at the leaves.
 > - A free monad is an expression tree with variables at the leaves and flatMap is variable substitution.
 
 #### Free monoid using Free

--- a/docs/08/d.md
+++ b/docs/08/d.md
@@ -114,7 +114,7 @@ type Option[+A] = Free[Trivial, A]
 There's also iteratees implementation based on free monads.
 Finally, he summarizes free monads in nice bullet points:
 
-> - A model for any recursive data type with data at the leaves.
+> - A model for any recursive datatype with data at the leaves.
 > - A free monad is an expression tree with variables at the leaves and flatMap is variable substitution.
 
 #### Free monoid using Free


### PR DESCRIPTION
The vast majority of usages are as one word. While "datatype" is a
nonstandard compound word, at least it's be consistent.
