### PR TITLE
Fix Triangle example

### DIFF
--- a/docs/11/a.md
+++ b/docs/11/a.md
@@ -33,12 +33,13 @@ scala> def triangle4: Unit = {
 We can abstract out 4 into a parameter:
 
 ```console
-scala> def triangle(side: Int): Unit = {
-         (1 to side) foreach { row =>
-           (1 to row) foreach { col =>
-             println("*")
-           }
-         }
+scala> def triangle2(side: Int): Unit = {
+          (1 to side) foreach { row =>
+            (1 to row) foreach { col =>
+              print("*")
+            }
+            print("\n")
+          }
        }
 ```
 


### PR DESCRIPTION
The current example doesn't work, it prints out each \*  on a new line. 

``` console
scala> def triangle(side: Int): Unit = {
     |          (1 to side) foreach { row =>
     |            (1 to row) foreach { col =>
     |              println("*")
     |            }
     |          }
     |        }
triangle: (side: Int)Unit

scala> triangle(4)
*
*
*
*
*
*
*
*
*
*

scala> def triangle2(side: Int): Unit = {
     |          (1 to side) foreach { row =>
     |            (1 to row) foreach { col =>
     | print("*")
     | }
     | print("\n")
     | }
     | }
triangle2: (side: Int)Unit

scala> triangle2(4)
*
**
***
****

scala> 
```
