### PR TITLE
Unable to look for scalaz deps

### DIFF
--- a/docs/01/a.md
+++ b/docs/01/a.md
@@ -24,6 +24,8 @@ val specs2Core  = "org.specs2" %% "specs2-core" % specs2Version
 val specs2Scalacheck = "org.specs2" %% "specs2-scalacheck" % specs2Version
 val scalacheck = "org.scalacheck" %% "scalacheck" % "1.12.4"
 
+resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
+
 lazy val root = (project in file(".")).
   settings(
     organization := "com.example",


### PR DESCRIPTION
Attempting to get CATS but ran into the issue of not being able to locate this dependency.

```
module not found: org.scalaz.stream#scalaz-stream_2.11;0.7a
```

The PR seems to work w/o much issues.
