### PR TITLE
Fix the links to the Free Monoids pages

### DIFF
--- a/docs/08/b-Free-monads.md
+++ b/docs/08/b-Free-monads.md
@@ -2,7 +2,7 @@
 out: Free-monads.html
 ---
 
-  [Free-monoids]: Free-monoids.htmls
+  [Free-monoids]: Free-monoids.html
   [@gabrielg439]: https://twitter.com/gabrielg439
   [wfmm]: http://www.haskellforall.com/2012/06/you-could-have-invented-free-monads.html
   [FreeSource]: $catsBaseUrl$free/src/main/scala/cats/free/Free.scala

--- a/docs/ja/08/b-Free-monads.md
+++ b/docs/ja/08/b-Free-monads.md
@@ -2,7 +2,7 @@
 out: Free-monads.html
 ---
 
-  [Free-monoids]: Free-monoids.htmls
+  [Free-monoids]: Free-monoids.html
   [@gabrielg439]: https://twitter.com/gabrielg439
   [wfmm]: http://www.haskellforall.com/2012/06/you-could-have-invented-free-monads.html
   [FreeSource]: $catsBaseUrl$free/src/main/scala/cats/free/Free.scala


### PR DESCRIPTION
The links to the "Free Monoids" pages in both English and Japanese:

* http://eed3si9n.com/herding-cats/ja/Free-monads.html

<img width="317" alt="screen shot 2017-09-04 at 13 58 40" src="https://user-images.githubusercontent.com/7414320/30012259-3ee85f3a-9179-11e7-8b3e-fb8397372ad6.png">

* http://eed3si9n.com/herding-cats/Free-monads.html

<img width="215" alt="screen shot 2017-09-04 at 13 58 49" src="https://user-images.githubusercontent.com/7414320/30012257-3ee7f9fa-9179-11e7-851b-7764df5dfc76.png">

will both read you to a 404 page, due to the extra `s`'s as in this pull request.

<img width="350" alt="screen shot 2017-09-04 at 13 58 58" src="https://user-images.githubusercontent.com/7414320/30012258-3ee830d2-9179-11e7-803b-9e333a593c60.png">

